### PR TITLE
fix: prevent unnecessary scroll state re-renders

### DIFF
--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -174,11 +174,19 @@ export const useStickToBottom = (
 	}, []);
 
 	const setIsAtBottom = useCallback((isAtBottom: boolean) => {
+		if (state.isAtBottom === isAtBottom) {
+			return;
+		}
+
 		state.isAtBottom = isAtBottom;
 		updateIsAtBottom(isAtBottom);
 	}, []);
 
 	const setEscapedFromLock = useCallback((escapedFromLock: boolean) => {
+		if (state.escapedFromLock === escapedFromLock) {
+			return;
+		}
+
 		state.escapedFromLock = escapedFromLock;
 		updateEscapedFromLock(escapedFromLock);
 	}, []);


### PR DESCRIPTION
## Summary

Fixes issue #14 by preventing unnecessary React state updates when
`isAtBottom` or `escapedFromLock` have not actually changed.

### Changes

- Avoid calling `updateIsAtBottom` when the value is unchanged.
- Avoid calling `updateEscapedFromLock` when the value is unchanged.
- This prevents unnecessary component re-renders during scrolling.

### Verification

- `pnpm build` passes.
- `pnpm lint` passes.
- Verified the demo manually by scrolling up/down and returning to the bottom.
- Confirmed that the scroll state only updates when the relevant state actually changes.