### PR TITLE
fix: release the scroll lock when the user scrolls during a resize

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"files": {
-		"include": ["src/**/*.ts", "src/**/*.tsx"],
+		"include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts"],
 		"ignore": ["**/dist/**"]
 	},
 	"linter": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "vite",
     "build": "rm -rf dist > /dev/null 2>&1; tsc -b",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "lint": "biome check",
     "lint:fix": "pnpm lint --write"
   },
@@ -34,14 +35,17 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@egoist/tailwindcss-icons": "^1.8.1",
     "@iconify-json/ph": "^1.2.0",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
     "globals": "^15.9.0",
+    "jsdom": "^26.1.0",
     "lorem-ipsum": "^2.0.8",
     "postcss": "^8.4.45",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -50,7 +54,7 @@
     "typescript": "^5.5.3",
     "vite": "^5.4.1",
     "vite-plugin-dts": "^4.2.1",
-    "@biomejs/biome": "^1.9.4"
+    "vitest": "^3.2.7"
   },
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
 }

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -433,6 +433,32 @@ export const useStickToBottom = (
 			setIsNearBottom(state.isNearBottom);
 
 			/**
+			 * A scroll that we didn't perform ourselves (`ignoreScrollToTop` is
+			 * unset), that moves upwards, and that lands away from the target can
+			 * only have come from the user - a resize never moves the reader away
+			 * from the bottom. Growing content leaves `scrollTop` untouched, and
+			 * shrinking content only ever clamps it towards the bottom.
+			 *
+			 * This has to be recognised here rather than in the deferred handler
+			 * below, because that one bails out for as long as a resize is in
+			 * progress, which during streaming is very nearly always.
+			 */
+			const isUserEscape =
+				ignoreScrollToTop === undefined &&
+				scrollTop < lastScrollTop &&
+				!state.isNearBottom;
+
+			if (
+				isUserEscape &&
+				state.resizeDifference &&
+				!state.animation?.ignoreEscapes
+			) {
+				setEscapedFromLock(true);
+				setIsAtBottom(false);
+				return;
+			}
+
+			/**
 			 * Scroll events may come before a ResizeObserver event,
 			 * so in order to ignore resize events correctly we use a
 			 * timeout.
@@ -441,9 +467,15 @@ export const useStickToBottom = (
 			 */
 			setTimeout(() => {
 				/**
-				 * When theres a resize difference ignore the resize event.
+				 * When theres a resize difference ignore the resize event, unless
+				 * the user escaped the lock - the scroll event can arrive before
+				 * the resize event it belongs to, so a user escape can still be
+				 * sitting here once the resize difference has been set.
 				 */
-				if (state.resizeDifference || scrollTop === ignoreScrollToTop) {
+				if (
+					(state.resizeDifference && !isUserEscape) ||
+					scrollTop === ignoreScrollToTop
+				) {
 					return;
 				}
 

--- a/test/useStickToBottom.test.ts
+++ b/test/useStickToBottom.test.ts
@@ -1,0 +1,272 @@
+/*!---------------------------------------------------------------------------------------------
+ *  Copyright (c) StackBlitz. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useStickToBottom } from "../src/useStickToBottom";
+
+type ResizeCallback = (entries: { contentRect: { height: number } }[]) => void;
+
+const CLIENT_HEIGHT = 500;
+const INITIAL_CONTENT_HEIGHT = 1000;
+
+let resizeCallbacks: ResizeCallback[] = [];
+
+class MockResizeObserver {
+	constructor(callback: ResizeCallback) {
+		resizeCallbacks.push(callback);
+	}
+
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+/**
+ * jsdom has no layout engine, so the scroll geometry that the hook reads is
+ * defined by hand, and content resizes are delivered by invoking the observer
+ * callback directly.
+ */
+function createScrollElements() {
+	const scrollElement = document.createElement("div");
+	const contentElement = document.createElement("div");
+
+	scrollElement.appendChild(contentElement);
+	document.body.appendChild(scrollElement);
+
+	let scrollHeight = INITIAL_CONTENT_HEIGHT;
+	let scrollTop = 0;
+
+	Object.defineProperty(scrollElement, "clientHeight", {
+		configurable: true,
+		get: () => CLIENT_HEIGHT,
+	});
+
+	Object.defineProperty(scrollElement, "scrollHeight", {
+		configurable: true,
+		get: () => scrollHeight,
+	});
+
+	Object.defineProperty(scrollElement, "scrollTop", {
+		configurable: true,
+		get: () => scrollTop,
+		set: (value: number) => {
+			scrollTop = Math.max(0, Math.min(value, scrollHeight - CLIENT_HEIGHT));
+		},
+	});
+
+	return {
+		scrollElement,
+		contentElement,
+
+		/**
+		 * The scroll position the hook sticks to, as derived by the hook itself.
+		 */
+		get targetScrollTop() {
+			return scrollHeight - 1 - CLIENT_HEIGHT;
+		},
+
+		/**
+		 * Grows or shrinks the content and delivers the resize to the observer,
+		 * the way a streamed message would.
+		 */
+		resize(height: number) {
+			scrollHeight = height;
+
+			for (const callback of resizeCallbacks) {
+				callback([{ contentRect: { height } }]);
+			}
+		},
+
+		/**
+		 * A scroll that the hook did not perform itself - a user dragging the
+		 * scrollbar, a touch drag, or a keyboard scroll. It deliberately writes
+		 * the DOM property directly so that `ignoreScrollToTop` stays unset.
+		 */
+		userScrollTo(value: number) {
+			scrollElement.scrollTop = value;
+			scrollElement.dispatchEvent(new Event("scroll"));
+		},
+	};
+}
+
+type Harness = ReturnType<typeof createScrollElements>;
+
+function renderStickToBottom(harness: Harness) {
+	const { result } = renderHook(() => useStickToBottom());
+
+	act(() => {
+		result.current.scrollRef(harness.scrollElement);
+		result.current.contentRef(harness.contentElement);
+	});
+
+	return result;
+}
+
+/**
+ * Leaves the reader locked to the bottom with a resize in flight, which is the
+ * steady state while a message streams in.
+ */
+function streamToBottom(
+	harness: Harness,
+	result: { current: ReturnType<typeof useStickToBottom> },
+) {
+	act(() => {
+		harness.resize(INITIAL_CONTENT_HEIGHT);
+	});
+
+	act(() => {
+		harness.userScrollTo(harness.targetScrollTop);
+	});
+
+	act(() => {
+		harness.resize(INITIAL_CONTENT_HEIGHT + 400);
+	});
+
+	expect(result.current.state.resizeDifference).not.toBe(0);
+	expect(result.current.state.isAtBottom).toBe(true);
+}
+
+describe("useStickToBottom", () => {
+	beforeEach(() => {
+		resizeCallbacks = [];
+		globalThis.ResizeObserver =
+			MockResizeObserver as unknown as typeof ResizeObserver;
+
+		// The hook defers part of its scroll handling by 1ms; faking only the
+		// timers keeps that deferral controllable while leaving the animation
+		// loop's requestAnimationFrame untouched.
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		document.body.innerHTML = "";
+	});
+
+	it("releases the lock when the user scrolls away while the content resizes", () => {
+		const harness = createScrollElements();
+		const result = renderStickToBottom(harness);
+
+		streamToBottom(harness, result);
+
+		act(() => {
+			harness.userScrollTo(200);
+		});
+
+		expect(result.current.state.isAtBottom).toBe(false);
+		expect(result.current.escapedFromLock).toBe(true);
+		expect(result.current.isAtBottom).toBe(false);
+
+		// A further resize must not pull the reader back down.
+		act(() => {
+			harness.resize(INITIAL_CONTENT_HEIGHT + 800);
+		});
+
+		expect(result.current.state.isAtBottom).toBe(false);
+		expect(harness.scrollElement.scrollTop).toBe(200);
+	});
+
+	it("keeps the release after the deferred handler runs", () => {
+		const harness = createScrollElements();
+		const result = renderStickToBottom(harness);
+
+		streamToBottom(harness, result);
+
+		act(() => {
+			harness.userScrollTo(200);
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(5);
+		});
+
+		expect(result.current.state.isAtBottom).toBe(false);
+		expect(result.current.escapedFromLock).toBe(true);
+	});
+
+	it("keeps the lock when the resize itself moves the scroll position", () => {
+		const harness = createScrollElements();
+		const result = renderStickToBottom(harness);
+
+		act(() => {
+			harness.resize(INITIAL_CONTENT_HEIGHT);
+		});
+
+		act(() => {
+			harness.userScrollTo(harness.targetScrollTop);
+		});
+
+		// Shrinking the content forces the hook to pull the scroll position back
+		// to the new target, which marks the scroll via `ignoreScrollToTop`.
+		act(() => {
+			harness.resize(INITIAL_CONTENT_HEIGHT - 300);
+		});
+
+		expect(harness.scrollElement.scrollTop).toBe(harness.targetScrollTop);
+		expect(result.current.state.ignoreScrollToTop).toBe(
+			harness.targetScrollTop,
+		);
+
+		act(() => {
+			harness.scrollElement.dispatchEvent(new Event("scroll"));
+			vi.advanceTimersByTime(5);
+		});
+
+		expect(result.current.state.isAtBottom).toBe(true);
+		expect(result.current.escapedFromLock).toBe(false);
+	});
+
+	it("keeps the lock when a scroll during a resize stays near the bottom", () => {
+		const harness = createScrollElements();
+		const result = renderStickToBottom(harness);
+
+		streamToBottom(harness, result);
+
+		// Caught up with the grown content, then nudged up by less than the
+		// stick-to-bottom offset - too small to read as leaving the bottom.
+		act(() => {
+			harness.userScrollTo(harness.targetScrollTop);
+		});
+
+		act(() => {
+			harness.userScrollTo(harness.targetScrollTop - 20);
+		});
+
+		expect(result.current.state.isAtBottom).toBe(true);
+		expect(result.current.escapedFromLock).toBe(false);
+	});
+
+	it("honours ignoreEscapes when the user scrolls away during a resize", () => {
+		const harness = createScrollElements();
+		const result = renderStickToBottom(harness);
+
+		streamToBottom(harness, result);
+
+		const lastScrollTop = harness.scrollElement.scrollTop;
+
+		result.current.state.animation = {
+			behavior: "instant",
+			ignoreEscapes: true,
+			promise: Promise.resolve(true),
+		};
+
+		act(() => {
+			harness.userScrollTo(200);
+		});
+
+		expect(result.current.state.isAtBottom).toBe(true);
+		expect(result.current.escapedFromLock).toBe(false);
+
+		// The deferred handler restores the position the escape tried to leave.
+		act(() => {
+			vi.advanceTimersByTime(5);
+		});
+
+		expect(harness.scrollElement.scrollTop).toBe(lastScrollTop);
+		expect(result.current.state.isAtBottom).toBe(true);
+		expect(result.current.escapedFromLock).toBe(false);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.demo.json" },
+    { "path": "./tsconfig.test.json" },
     { "path": "./tsconfig.node.json" }
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,5 +18,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "isolatedDeclarations": false,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vitest/globals"]
+  },
+  "include": ["test"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['test/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## The problem

While a message streams in, scrolling away from the bottom can fail to take effect: the view snaps back down as soon as the next chunk of content arrives, and `isAtBottom` never becomes `false`.

`handleScroll` defers most of its work by a millisecond, so that scroll events caused by a resize can be ignored, and the deferred handler bails out whenever `state.resizeDifference` is set:

```ts
setTimeout(() => {
  if (state.resizeDifference || scrollTop === ignoreScrollToTop) {
    return;
  }
  // ...the code that calls setEscapedFromLock(true) / setIsAtBottom(false)
}, 1);
```

`resizeDifference` is only cleared a frame-plus-a-millisecond after the resize that set it:

```ts
requestAnimationFrame(() => {
  setTimeout(() => {
    if (state.resizeDifference === difference) {
      state.resizeDifference = 0;
    }
  }, 1);
});
```

During streaming, the `ResizeObserver` fires continuously, so each resize re-arms the value before the previous one is cleared and it is nearly never back to `0`. A genuine user scroll that lands in that window never reaches the escape logic. `state.isAtBottom` stays `true`, so the next positive resize scrolls to the bottom again and drags the reader back down.

This is easiest to hit **without a mouse wheel**. `handleWheel` escapes on any upward `deltaY` and is not gated on `resizeDifference`, so wheel users are already covered — which is probably why this has gone unnoticed. Touch drags, scrollbar drags, and keyboard scrolling produce only `scroll` events and go through the broken path.

## The fix

Recognise the case synchronously, before the deferred handler gets a chance to bail:

```ts
const isUserEscape =
  ignoreScrollToTop === undefined &&
  scrollTop < lastScrollTop &&
  !state.isNearBottom;
```

A scroll can only be a user escape if all three hold:

- **`ignoreScrollToTop === undefined`** — the hook marks every scroll it performs itself through the `state.scrollTop` setter, so an unmarked event did not come from the animation or from the overscroll correction.
- **moving upwards** — growing content leaves `scrollTop` untouched, so a resize alone never produces upward movement.
- **landing further than `STICK_TO_BOTTOM_OFFSET_PX` from the target** — shrinking content only ever clamps `scrollTop` *towards* the bottom, so resize-induced movement stays near the target. This is the condition that keeps browser scroll-anchoring and clamping jitter from being mistaken for intent, which matters more than reacting to a very small nudge: getting this wrong would break the sticking behaviour itself.

When that holds during a resize, the lock is released immediately. The same flag also relaxes the deferred bail-out, for the documented case where the scroll event arrives *before* the resize event it belongs to — then `resizeDifference` is still `0` at event time and only set by the time the deferred handler runs.

Both existing escape hatches keep their meaning:

- **`ignoreScrollToTop`** — marked scrolls are never treated as an escape.
- **`animation.ignoreEscapes`** — the synchronous path skips the release, and the deferred handler now restores the position with `state.scrollTop = lastScrollTop`. Previously that restore was skipped entirely during a resize, so `ignoreEscapes` was quietly not honoured while content was streaming.

## Tests

The repo had no test runner, so this adds a minimal `vitest` project (jsdom environment) in a separate commit. It is typechecked as part of `tsc -b`, linted alongside `src`, and keeps its build info out of `dist`. `pnpm test` runs it.

jsdom has no layout engine, so the test defines the scroll geometry by hand and delivers resizes by invoking the observer callback, which also makes the ordering deterministic. Only `setTimeout` is faked, leaving the animation loop's `requestAnimationFrame` alone.

Five tests, covering the fix and the two ways it could go wrong. Against the unfixed hook, three fail and two pass:

| Test | Before |
| --- | --- |
| releases the lock when the user scrolls away while the content resizes | fails |
| keeps the release after the deferred handler runs | fails |
| honours `ignoreEscapes` when the user scrolls away during a resize | fails (no restore) |
| keeps the lock when the resize itself moves the scroll position | passes |
| keeps the lock when a scroll during a resize stays near the bottom | passes |

The last two are guards against false escapes, and are expected to pass either way.

## One thing to note

I was not able to include the regenerated `pnpm-lock.yaml` in this PR, so the lockfile still needs a `pnpm install` for the three new devDependencies (`vitest`, `jsdom`, `@testing-library/react`). Everything else is complete: `pnpm install`, `pnpm test`, `pnpm lint`, and `pnpm build` all pass on this branch as pushed, and `dist` is unchanged apart from the fix. Happy to drop the test harness into a separate PR, swap the runner, or trim the new dependencies if you would rather keep the dependency surface smaller.